### PR TITLE
Fix template for variable group retrieval.

### DIFF
--- a/.azure-pipelines/sfpowerscripts-build-deploy.yml
+++ b/.azure-pipelines/sfpowerscripts-build-deploy.yml
@@ -44,7 +44,7 @@ stages:
           - job: DeployJob
             displayName: 'Deploy the packages'
             variables:
-                group: DEVHUB
+              - group: DEVHUB
             pool:
                 vmImage: 'ubuntu-latest'
             container: dxatscale/sfpowerscripts:latest

--- a/.azure-pipelines/sfpowerscripts-prepare.yml
+++ b/.azure-pipelines/sfpowerscripts-prepare.yml
@@ -16,7 +16,7 @@ pool:
 container: dxatscale/sfpowerscripts:latest
 
 variables:
-    group: DEVHUB
+  - group: DEVHUB
 
 steps:
     - task: DownloadSecureFile@1

--- a/.azure-pipelines/sfpowerscripts-validate.yml
+++ b/.azure-pipelines/sfpowerscripts-validate.yml
@@ -14,7 +14,7 @@ pool:
 container: dxatscale/sfpowerscripts:latest
 
 variables:
-    group: DEVHUB
+  - group: DEVHUB
 
 steps:
 


### PR DESCRIPTION
This commit contains the fix for Azure yaml templates where it had the wrong syntax when retrieving variable groups. 

Documentation here: https://docs.microsoft.com/en-us/azure/devops/pipelines/library/variable-groups?view=azure-devops&tabs=yaml