### PR TITLE
Fix for Release, Build & Deploy, and Prepare pipelines auto trigger on PR

### DIFF
--- a/.azure-pipelines/sfpowerscripts-build-deploy.yml
+++ b/.azure-pipelines/sfpowerscripts-build-deploy.yml
@@ -2,6 +2,7 @@ name: Build and Release
 
 trigger:
     - develop
+pr: none
 
 stages:
     - stage: QuickBuild

--- a/.azure-pipelines/sfpowerscripts-fetch-release.yml
+++ b/.azure-pipelines/sfpowerscripts-fetch-release.yml
@@ -1,6 +1,7 @@
 name: Fetch and Release
 
 trigger: none
+pr: none
 
 stages:
     - stage: release

--- a/.azure-pipelines/sfpowerscripts-prepare.yml
+++ b/.azure-pipelines/sfpowerscripts-prepare.yml
@@ -1,6 +1,7 @@
 # Prepare a pool of scratch orgs
 
 trigger: none
+pr: none
 
 schedules:
     - cron: '0 0 * * *'


### PR DESCRIPTION
Release, Build & Deploy, and Prepare pipelines are auto-triggering when a PR is opened.

This PR aims to fix this behavior by setting `pr: none` for the three YAML samples.